### PR TITLE
fix: トークtxtから相手の名前を抽出する正規表現に英語を追加

### DIFF
--- a/line/backend/src/functions/__tests__/webhook.test.ts
+++ b/line/backend/src/functions/__tests__/webhook.test.ts
@@ -1,7 +1,7 @@
-import { it } from "vitest";
-import { parseTalkHistories } from "../webhook.js";
+import { expect, it } from "vitest";
+import { getYourName, parseTalkHistories } from "../webhook.js";
 
-it("トーク履歴が正しくparseされるか", () => {
+it("トーク履歴が正しくparseされるか (日本語)", () => {
   const text = `[LINE] 太郎とのトーク履歴
 保存日時：2025/1/13 1:21
 
@@ -10,5 +10,75 @@ it("トーク履歴が正しくparseされるか", () => {
 0:34	太郎	元気？
 `;
   const res = parseTalkHistories(text, "ぽ");
-  console.log(res);
+  expect(res).toEqual([
+    {
+      $typeName: "backend.v1.TalkHistory",
+      date: "2025-01-12T00:33:00+0900",
+      user: {
+        $typeName: "backend.v1.User",
+        name: "太郎",
+        userId: "太郎01",
+        role: 1,
+      },
+      message: "こんにちは！",
+    },
+    {
+      $typeName: "backend.v1.TalkHistory",
+      date: "2025-01-12T00:34:00+0900",
+      user: {
+        $typeName: "backend.v1.User",
+        name: "太郎",
+        userId: "太郎01",
+        role: 1,
+      },
+      message: "元気？",
+    },
+  ]);
+});
+
+it("トーク履歴が正しくparseされるか (英語)", () => {
+  const text = `Chat history with 太郎
+Saved on: 1/13/2025, 1:21
+
+Sun, 1/12/2025
+00:33	太郎	こんにちは！
+00:34	太郎	元気？
+`;
+  const res = parseTalkHistories(text, "ぽ");
+  expect(res).toEqual([
+    {
+      $typeName: "backend.v1.TalkHistory",
+      date: "2025-01-12T00:33:00+0900",
+      user: {
+        $typeName: "backend.v1.User",
+        name: "太郎",
+        userId: "太郎01",
+        role: 1,
+      },
+      message: "こんにちは！",
+    },
+    {
+      $typeName: "backend.v1.TalkHistory",
+      date: "2025-01-12T00:34:00+0900",
+      user: {
+        $typeName: "backend.v1.User",
+        name: "太郎",
+        userId: "太郎01",
+        role: 1,
+      },
+      message: "元気？",
+    },
+  ]);
+});
+
+it("ファイル名からユーザー名を抽出 (日本語)", () => {
+  const filename = "[LINE] 太郎とのトーク.txt";
+  const res = getYourName(filename);
+  expect(res).toEqual("太郎");
+});
+
+it("ファイル名からユーザー名を抽出 (英語)", () => {
+  const filename = "Chat history with 太郎.txt";
+  const res = getYourName(filename);
+  expect(res).toEqual("太郎");
 });

--- a/line/backend/src/functions/webhook.ts
+++ b/line/backend/src/functions/webhook.ts
@@ -169,7 +169,8 @@ export const webhookHandler = async (
             const decoder = new TextDecoder("utf-8");
             const talk = decoder.decode(buffer);
             console.log("file contents:", talk);
-            const match = talk.match(/\[LINE\] (.*?)とのトーク履歴/);
+            // TODO: こちらに関して、多言語に対応する必要がある
+            const match = talk.match(/\[LINE\] (?:Chat history with|.+とのトーク履歴) (.+)/);
             let yourName = "noName";
             // biome-ignore lint/complexity/useOptionalChain: <explanation>
             if (match && match[1]) {

--- a/line/backend/src/functions/webhook.ts
+++ b/line/backend/src/functions/webhook.ts
@@ -60,36 +60,69 @@ async function sendQuestionnaire(messageNumber: string): Promise<any> {
   }
 }
 
+export function getYourName(talk: string): string {
+  const match = talk.match(
+    /(?:\[LINE\] |Chat history with )(.+?)(?:とのトーク|\.txt)/,
+  );
+  return match ? match[1] : "noName";
+}
+
+export function getDate(row: string): string | undefined {
+  let talkDate: string | undefined = undefined;
+  const newDateMatch = row.match(
+    /^(\d{4})\/(\d{1,2})\/(\d{1,2})|^(Sun|Mon|Tue|Wed|Thu|Fri|Sat), (\d{1,2})\/(\d{1,2})\/(\d{4})/,
+  );
+
+  if (newDateMatch) {
+    if (newDateMatch[1] && newDateMatch[2] && newDateMatch[3]) {
+      // フォーマット: 2025/1/12(日)
+      const year = newDateMatch[1];
+      const month = newDateMatch[2].padStart(2, "0");
+      const day = newDateMatch[3].padStart(2, "0");
+      talkDate = `${year}-${month}-${day}`;
+    } else if (
+      newDateMatch[4] &&
+      newDateMatch[5] &&
+      newDateMatch[6] &&
+      newDateMatch[7]
+    ) {
+      // フォーマット: Sun, 1/12/2025
+      const month = newDateMatch[5].padStart(2, "0");
+      const day = newDateMatch[6].padStart(2, "0");
+      const year = newDateMatch[7];
+      talkDate = `${year}-${month}-${day}`;
+    } else {
+      talkDate = undefined;
+    }
+    return talkDate;
+  }
+}
+
 export function parseTalkHistories(
   talk: string,
   yourName: string,
 ): TalkHistory[] {
   const rows = talk.split("\n");
   const TalkHistories: TalkHistory[] = [];
-  let talkDate: string | null = null;
-  let dateMatch: RegExpMatchArray | null = null;
+  let talkDate: string | undefined = undefined;
 
   for (const row of rows) {
     const trimmedRow = row.trim();
     // 日付
-    const newDateMatch = trimmedRow.match(/^(\d{4})\/(\d{1,2})\/(\d{1,2})/);
-    if (newDateMatch) {
-      dateMatch = newDateMatch;
+    const newTalkDate = getDate(trimmedRow);
+    if (newTalkDate) {
+      talkDate = newTalkDate;
     }
-    if (dateMatch === null) {
+    if (talkDate === undefined) {
       continue;
     }
-    const year = dateMatch[1];
-    const month = dateMatch[2].padStart(2, "0");
-    const day = dateMatch[3].padStart(2, "0");
-    talkDate = `${year}-${month}-${day}`;
-
     // メッセージ（例: "22:07   Test    おはよう"）
     const messageMatch = trimmedRow.match(
-      /^(\d{1,2}:\d{2})\t+([^\t]+)?\t+(.+)$/,
+      /^(\d{1,2}):(\d{2})\t+([^\t]+)?\t+(.+)$/,
     );
     if (messageMatch && talkDate) {
-      const [_, time, userName, message] = messageMatch;
+      const [_, hour, minutes, userName, message] = messageMatch;
+      const time = `${hour.padStart(2, "0")}:${minutes}`;
       console.log("name:", userName);
       const dateTime = `${talkDate}T${time}:00+0900`; // ISO 8601形式
 
@@ -170,13 +203,8 @@ export const webhookHandler = async (
             const talk = decoder.decode(buffer);
             console.log("file contents:", talk);
             // TODO: こちらに関して、多言語に対応する必要がある
-            const match = talk.match(/\[LINE\] (?:Chat history with|.+とのトーク履歴) (.+)/);
-            let yourName = "noName";
-            // biome-ignore lint/complexity/useOptionalChain: <explanation>
-            if (match && match[1]) {
-              yourName = match[1];
-              console.log("Hostname:", yourName);
-            }
+            const yourName = getYourName(talk);
+            console.log("Hostname:", yourName);
 
             const TalkHistories = parseTalkHistories(talk, yourName);
             console.log("TalkHistories:", TalkHistories);


### PR DESCRIPTION
# やったこと

- LINEのトーク履歴 txtファイルのタイトルから相手の名前を抽出する正規表現に英語を追加